### PR TITLE
Feat/windows pat support

### DIFF
--- a/__tests__/unit/commands/show.test.ts
+++ b/__tests__/unit/commands/show.test.ts
@@ -102,21 +102,7 @@ describe('show command', () => {
         });
     });
 
-    it('should show PAT as not supported on Windows', async () => {
-        mockPlatform = 'win32';
-        mocks.getProfile.mockReturnValue({
-            name: 'pat-profile',
-            display_name: 'PAT User',
-            email: 'ansuman@gmail.com',
-            auth_method: 'pat',
-            created_at: '2026-05-28',
-        });
 
-        const code = await runShowCommand('pat-profile', false);
-
-        expect(code).toBe(ExitCode.SUCCESS);
-        expect(consoleOutput).toContain('PAT: not supported on Windows');
-    });
 
     it('should handle errors gracefully', async () => {
         mocks.getProfile.mockImplementation(() => {

--- a/__tests__/unit/core/credentialStore.test.ts
+++ b/__tests__/unit/core/credentialStore.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../src/core/credentialManagement/credentialStore';
 import { ProfileError } from '../../../src/core/profileManagement/errorClass';
 import * as constants from '../../../src/lib/constants';
+import fs from 'node:fs';
 
 vi.mock('../../../src/lib/constants', async (importOriginal) => {
   const original = await importOriginal<any>();
@@ -21,28 +22,59 @@ vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(),
 }));
 
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  }
+}));
+
 describe('credentialStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (constants as any).PLATFORM = 'darwin';
   });
 
-  describe('Windows platform validation', () => {
+  describe('Windows platform operations', () => {
     beforeEach(() => {
       (constants as any).PLATFORM = 'win32';
+      vi.mocked(fs.existsSync).mockReturnValue(false);
     });
 
-    it('should throw ProfileError for storePatForProfile on Windows', async () => {
-      await expect(storePatForProfile('work', 'ghp_token')).rejects.toThrow(ProfileError);
-      await expect(storePatForProfile('work', 'ghp_token')).rejects.toThrow('PAT Authentication is not supported on Windows.');
+    it('should successfully store PAT on Windows', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      await storePatForProfile('work', 'ghp_win_token');
+      expect(fs.mkdirSync).toHaveBeenCalledWith(constants.CREDENTIALS_DIR, { recursive: true });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(expect.stringContaining('work.json'), JSON.stringify({ pat: 'ghp_win_token' }), { encoding: 'utf-8' });
     });
 
-    it('should throw ProfileError for getPatForProfile on Windows', async () => {
-      await expect(getPatForProfile('work')).rejects.toThrow(ProfileError);
+    it('should return PAT if found on Windows', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ pat: 'ghp_retrieved_win' }));
+      const token = await getPatForProfile('work');
+      expect(token).toBe('ghp_retrieved_win');
     });
 
-    it('should throw ProfileError for deletePatForProfile on Windows', async () => {
-      await expect(deletePatForProfile('work')).rejects.toThrow(ProfileError);
+    it('should return null if file invalid on Windows', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error(); });
+      const token = await getPatForProfile('work');
+      expect(token).toBeNull();
+    });
+
+    it('should return null if file does not exist on Windows', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      const token = await getPatForProfile('work');
+      expect(token).toBeNull();
+    });
+
+    it('should delete PAT on Windows', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      await deletePatForProfile('work');
+      expect(fs.unlinkSync).toHaveBeenCalledWith(expect.stringContaining('work.json'));
     });
   });
 

--- a/__tests__/unit/utils/checkPatAuth.test.ts
+++ b/__tests__/unit/utils/checkPatAuth.test.ts
@@ -39,17 +39,7 @@ describe('checkPatAuth', () => {
     mockPlatform = 'darwin';
   });
 
-  it('should return fail result on Windows', async () => {
-    mockPlatform = 'win32';
-    const results = await checkPatAuth(mockProfile);
 
-    expect(results).toHaveLength(1);
-    expect(results[0]).toEqual({
-      label: 'PAT auth [pat-profile]',
-      status: 'fail',
-      message: 'PAT authentication is not supported on Windows',
-    });
-  });
 
   it('should pass PAT stored check if PAT is present in keychain', async () => {
     vi.mocked(hasPatForProfile).mockResolvedValue(true);
@@ -64,7 +54,7 @@ describe('checkPatAuth', () => {
     expect(results[0]).toEqual({
       label: 'PAT stored [pat-profile]',
       status: 'pass',
-      message: 'PAT found in OS keychain',
+      message: 'PAT found in credential store',
     });
     expect(results[1]).toEqual({
       label: 'Git credential helper [pat-profile]',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { runCurrentCommand } from './commands/current';
 import { runRemoveCommand } from './commands/remove';
 import { runShowCommand } from './commands/show';
 import { runInitCommand } from './commands/init';
-import { setOutputFlags } from './utils/output';
+import { setOutputFlags, fmt, printError } from './utils/output';
 import type { GlobalCliOptions } from './lib/types/GpxConfig.type';
 import { runCompletionCommand } from './commands/completion';
 import { runRunCommand } from './commands/run';
@@ -22,7 +22,6 @@ import { runEditCommand } from './commands/edit';
 import { runPatSetCommand, runPatClearCommand } from './commands/pat';
 import { runGitCredentialCommand } from './core/credentialManagement/gpxCredentialHelper';
 import { password, select } from '@inquirer/prompts';
-import { PLATFORM } from './lib/constants';
 
 await yargs(hideBin(process.argv))
   .scriptName('gpx')
@@ -55,22 +54,19 @@ await yargs(hideBin(process.argv))
     async (argv: any) => {
       // Skip select() if --auth-method was provided via flag
       if (!argv.authMethod) {
-        if (PLATFORM === 'win32') {
-          argv.authMethod = 'ssh';
-        } else {
-          argv.authMethod = await select({
-            message: 'Add Profile using:',
-            choices: [
-              { name: 'Secure Shell (SSH)', value: 'ssh' },
-              { name: 'Personal Access Token (PAT)', value: 'pat' },
-            ],
-            theme: {
-              style: {
-                keysHelpTip: () => undefined,
-              },
+        argv.authMethod = await select({
+          message: 'Add Profile using:',
+          choices: [
+            { name: 'Secure Shell (SSH)', value: 'ssh' },
+            { name: 'Personal Access Token (PAT)', value: 'pat' },
+          ],
+          theme: {
+            style: {
+              answer: (text: string) => fmt.green(text),
+              keysHelpTip: () => undefined,
             },
-          });
-        }
+          },
+        });
       }
 
       if (argv.authMethod === 'ssh') {
@@ -89,7 +85,7 @@ await yargs(hideBin(process.argv))
       } else {
         // Skip password() prompt if --pat flag was provided directly
         if (!argv.pat) {
-          argv.pat = await password({ message: 'Enter Personal Access Token:' });
+          argv.pat = await password({ message: 'Enter Personal Access Token:', mask: '*' });
         }
         process.exitCode = await runPatAddCommand({
           name: argv.name,
@@ -310,4 +306,17 @@ await yargs(hideBin(process.argv))
   .demandCommand(1, 'Use a command. Try: gpx --help')
   .strict()
   .help()
+  .fail((msg, err, yargs) => {
+    if (err && (err.name === 'ExitPromptError' || err.message?.includes('User force closed'))) {
+      printError('\nCommand Terminated');
+      process.exit(1);
+    }
+    if (msg) {
+      yargs.showHelp();
+      printError(`\n${msg}`);
+    } else if (err) {
+      printError(`${err}`);
+    }
+    process.exit(1);
+  })
   .parseAsync();

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -9,7 +9,6 @@ import { upsertSshConfigForProfile } from '../core/sshConfigManagement/sshconfig
 import { validatePat } from '../core/githubManagement/validatePat';
 import { storePatForProfile } from '../core/credentialManagement/credentialStore';
 import { ensureCredentialHelperAdded } from '../core/credentialManagement/ensureHelper';
-import { PLATFORM } from '../lib/constants';
 
 const runSshAddCommand = async (args: AddArgs): Promise<number> => {
   try {
@@ -148,13 +147,6 @@ const runSshAddCommand = async (args: AddArgs): Promise<number> => {
 
 const runPatAddCommand = async (args: AddArgs): Promise<number> => {
   try {
-    if (PLATFORM === 'win32') {
-      throw new ProfileError(
-        'PAT authentication is not supported on Windows.',
-        ExitCode.INVALID_INPUT
-      );
-    }
-
     // Validate profile name
     const nameValidation = validateProfileName(args.name);
     if (!nameValidation.valid) {

--- a/src/commands/pat.ts
+++ b/src/commands/pat.ts
@@ -1,5 +1,5 @@
 import { getProfile } from '../core/profileManagement/profiles';
-import { ExitCode, PLATFORM } from '../lib/constants';
+import { ExitCode } from '../lib/constants';
 import { handleCommandError, printHuman, printJson, printSuccess } from '../utils/output';
 import { ProfileError } from '../core/profileManagement/errorClass';
 import {
@@ -16,13 +16,6 @@ const runPatSetCommand = async (
   json: boolean
 ): Promise<number> => {
   try {
-    if (PLATFORM === 'win32') {
-      throw new ProfileError(
-        'PAT authentication is not supported on Windows.',
-        ExitCode.INVALID_INPUT
-      );
-    }
-
     const profile = getProfile(profileName);
     if (!profile) {
       throw new ProfileError(`Profile not found: ${profileName}`, ExitCode.PROFILE_NOT_FOUND);
@@ -39,7 +32,10 @@ const runPatSetCommand = async (
     if (suppliedPat && suppliedPat.trim().length > 0) {
       pat = suppliedPat.trim();
     } else {
-      pat = await password({ message: `Enter new Personal Access Token for '${profileName}':` });
+      pat = await password({
+        message: `Enter new Personal Access Token for '${profileName}':`,
+        mask: '*',
+      });
     }
 
     if (!pat || pat.trim().length === 0) {
@@ -76,13 +72,6 @@ const runPatSetCommand = async (
 
 const runPatClearCommand = async (profileName: string, json: boolean): Promise<number> => {
   try {
-    if (PLATFORM === 'win32') {
-      throw new ProfileError(
-        'PAT authentication is not supported on Windows.',
-        ExitCode.INVALID_INPUT
-      );
-    }
-
     const profile = getProfile(profileName);
     if (!profile) {
       throw new ProfileError(`Profile not found: ${profileName}`, ExitCode.PROFILE_NOT_FOUND);

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -11,7 +11,6 @@ import {
   isInsideGitRepo,
 } from '../core/gitconfig';
 import { deletePatForProfile } from '../core/credentialManagement/credentialStore';
-import { PLATFORM } from '../lib/constants';
 
 export const runRemoveCommand = async (
   profileName: string,
@@ -37,7 +36,7 @@ export const runRemoveCommand = async (
     await removeSshConfigForProfile(profileName, profile?.ssh_key);
     if (profile?.ssh_key) moveSshKeysToRemoved(profile.ssh_key);
 
-    if (profile?.auth_method === 'pat' && PLATFORM !== 'win32') {
+    if (profile?.auth_method === 'pat') {
       await deletePatForProfile(profileName);
     }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { getProfile } from '../core/profileManagement/profiles';
 import { loadActive, saveActive } from '../core/profileManagement/activeStore';
-import { ExitCode, PLATFORM } from '../lib/constants';
+import { ExitCode } from '../lib/constants';
 import { handleCommandError, printJson, printSuccess } from '../utils/output';
 import { ProfileError } from '../core/profileManagement/errorClass';
 import { ensureCredentialHelperAdded } from '../core/credentialManagement/ensureHelper';
@@ -42,7 +42,7 @@ export async function runRunCommand(
     env['GPX_ACTIVE_PROFILE'] = profile.name;
 
     let prevActive: Awaited<ReturnType<typeof loadActive>> | null = null;
-    const isPat = profile.auth_method === 'pat' && PLATFORM !== 'win32';
+    const isPat = profile.auth_method === 'pat';
 
     const restoreProfile = async () => {
       if (prevActive !== null) await saveActive(prevActive);

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -4,7 +4,6 @@ import { ExitCode } from '../lib/constants';
 import { ProfileError } from '../core/profileManagement/errorClass';
 import { handleCommandError, printHuman, printJson, fmt } from '../utils/output';
 import { hasPatForProfile } from '../core/credentialManagement/credentialStore';
-import { PLATFORM } from '../lib/constants';
 
 export const runShowCommand = async (profileName: string, json: boolean): Promise<number> => {
   try {
@@ -17,7 +16,7 @@ export const runShowCommand = async (profileName: string, json: boolean): Promis
 
     // For PAT profiles, check if PAT is stored in keychain
     let patConfigured: boolean | null = null;
-    if (profile.auth_method === 'pat' && PLATFORM !== 'win32') {
+    if (profile.auth_method === 'pat') {
       patConfigured = await hasPatForProfile(profileName);
     }
 
@@ -45,13 +44,9 @@ export const runShowCommand = async (profileName: string, json: boolean): Promis
 
     if (profile.auth_method === 'pat') {
       humanOutputData.push(`GitHub username: ${profile.github_username ?? 'not set'}`);
-      if (PLATFORM === 'win32') {
-        humanOutputData.push(`PAT: not supported on Windows`);
-      } else {
-        humanOutputData.push(
-          `PAT: ${patConfigured ? fmt.green('configured ✓') : fmt.red('not configured ✗')}`
-        );
-      }
+      humanOutputData.push(
+        `PAT: ${patConfigured ? fmt.green('configured ✓') : fmt.red('not configured ✗')}`
+      );
     }
 
     humanOutputData.push(

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -11,7 +11,7 @@ import {
   httpsToSshAlias,
   safeGit,
 } from '../core/gitconfig';
-import { ExitCode, PLATFORM } from '../lib/constants';
+import { ExitCode } from '../lib/constants';
 import { handleCommandError, printJson, printSuccess, printWarn } from '../utils/output';
 import { ProfileError } from '../core/profileManagement/errorClass';
 import { upsertSshConfigForProfile } from '../core/sshConfigManagement/sshconfig';
@@ -91,13 +91,6 @@ export const runUseCommand = async (
         }
       }
     } else if (authMethod === 'pat') {
-      if (PLATFORM === 'win32') {
-        throw new ProfileError(
-          'PAT authentication is not supported on Windows.',
-          ExitCode.INVALID_INPUT
-        );
-      }
-
       ensureCredentialHelperAdded();
 
       if (local && isInsideGitRepo()) {

--- a/src/core/credentialManagement/credentialStore.ts
+++ b/src/core/credentialManagement/credentialStore.ts
@@ -1,20 +1,29 @@
 import { spawnSync } from 'node:child_process';
-import { PLATFORM, SERVICE } from '../../lib/constants';
+import { PLATFORM, SERVICE, CREDENTIALS_DIR } from '../../lib/constants';
 import { ExitCode } from '../../lib/constants';
 import { ProfileError } from '../profileManagement/errorClass';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const showErrorOnWindows = (): void => {
-  if (PLATFORM === 'win32') {
-    throw new ProfileError(
-      `PAT Authentication is not supported on Windows.`,
-      ExitCode.INVALID_INPUT
-    );
+const getCredentialFilePath = (profileName: string): string => {
+  return path.join(CREDENTIALS_DIR, `${profileName}.json`);
+};
+
+const ensureCredentialsDir = (): void => {
+  if (!fs.existsSync(CREDENTIALS_DIR)) {
+    fs.mkdirSync(CREDENTIALS_DIR, { recursive: true });
   }
 };
 
 const storePatForProfile = async (profileName: string, pat: string): Promise<void> => {
   try {
-    showErrorOnWindows();
+    if (PLATFORM === 'win32') {
+      ensureCredentialsDir();
+      const filePath = getCredentialFilePath(profileName);
+      fs.writeFileSync(filePath, JSON.stringify({ pat }), { encoding: 'utf-8' });
+      return;
+    }
+
     if (PLATFORM === 'darwin') {
       spawnSync('security', [
         'delete-generic-password',
@@ -81,9 +90,21 @@ const storePatForProfile = async (profileName: string, pat: string): Promise<voi
 };
 
 const getPatForProfile = async (profileName: string): Promise<string | null> => {
-  showErrorOnWindows();
-
   try {
+    if (PLATFORM === 'win32') {
+      const filePath = getCredentialFilePath(profileName);
+      if (fs.existsSync(filePath)) {
+        try {
+          const content = fs.readFileSync(filePath, { encoding: 'utf-8' });
+          const parsed = JSON.parse(content);
+          return parsed.pat || null;
+        } catch {
+          return null;
+        }
+      }
+      return null;
+    }
+
     let commandString: { command: string; args: string[] } | undefined;
 
     if (PLATFORM === 'darwin') {
@@ -114,9 +135,15 @@ const getPatForProfile = async (profileName: string): Promise<string | null> => 
 };
 
 const deletePatForProfile = async (profileName: string): Promise<void> => {
-  showErrorOnWindows();
-
   try {
+    if (PLATFORM === 'win32') {
+      const filePath = getCredentialFilePath(profileName);
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+      return;
+    }
+
     if (PLATFORM === 'darwin') {
       spawnSync('security', [
         'delete-generic-password',

--- a/src/core/credentialManagement/ensureHelper.ts
+++ b/src/core/credentialManagement/ensureHelper.ts
@@ -1,9 +1,7 @@
 import { spawnSync } from 'node:child_process';
-import { PLATFORM, GPX_CREDENTIAL_HELPER } from '../../lib/constants';
+import { GPX_CREDENTIAL_HELPER } from '../../lib/constants';
 
 export const ensureCredentialHelperAdded = (): void => {
-  if (PLATFORM === 'win32') return;
-
   const result = spawnSync('git', [
     'config',
     '--global',
@@ -31,7 +29,5 @@ export const ensureCredentialHelperAdded = (): void => {
 };
 
 export const removeCredentialHelper = (): void => {
-  if (PLATFORM === 'win32') return;
-
   spawnSync('git', ['config', '--global', '--remove-section', 'credential.https://github.com']);
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -23,6 +23,7 @@ const PROFILES_PATH: string = path.join(GPX_DIR, 'profiles.json');
 const ACTIVE_PATH: string = path.join(GPX_DIR, 'active.json');
 const CONFIG_PATH: string = path.join(GPX_DIR, 'config.json');
 const LOCK_PATH: string = path.join(GPX_DIR, '.lock');
+const CREDENTIALS_DIR: string = path.join(GPX_DIR, 'credentials');
 const CONFIG_DIR: string = path.join(os.homedir(), '.config', 'gpx');
 const CONFIG_FILE: string = path.join(CONFIG_DIR, 'config.json');
 
@@ -42,6 +43,7 @@ export {
   ACTIVE_PATH,
   CONFIG_PATH,
   LOCK_PATH,
+  CREDENTIALS_DIR,
   API_BASE,
   CONFIG_DIR,
   CONFIG_FILE,

--- a/src/utils/doctorCommandChecks/checkPatAuth.ts
+++ b/src/utils/doctorCommandChecks/checkPatAuth.ts
@@ -1,27 +1,18 @@
 import type { CheckResult } from '../../lib/types/CheckResult.type';
 import type { Profile } from '../../lib/types/Profile.type';
 import { hasPatForProfile } from '../../core/credentialManagement/credentialStore';
-import { PLATFORM, GPX_CREDENTIAL_HELPER } from '../../lib/constants';
+import { GPX_CREDENTIAL_HELPER } from '../../lib/constants';
 import { spawnSync } from 'node:child_process';
 
 export const checkPatAuth = async (profile: Profile): Promise<CheckResult[]> => {
   const results: CheckResult[] = [];
-
-  if (PLATFORM === 'win32') {
-    results.push({
-      label: `PAT auth [${profile.name}]`,
-      status: 'fail',
-      message: 'PAT authentication is not supported on Windows',
-    });
-    return results;
-  }
 
   const patPresent = await hasPatForProfile(profile.name);
   results.push({
     label: `PAT stored [${profile.name}]`,
     status: patPresent ? 'pass' : 'fail',
     message: patPresent
-      ? 'PAT found in OS keychain'
+      ? 'PAT found in credential store'
       : `No PAT found. Run: gpx pat set ${profile.name}`,
   });
 


### PR DESCRIPTION
## Extend Pat Support - Windows
## Description

### What does this PR do?

- Updated credentialManager for windows - stores PAT per gpx-profile - (.gpx/credentials)
- Removed windows restrictions from core + all pat-based commands
- Updated Cli.ts to allows pat-based options on windows

### Related Issues

- Closes 
#81 

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [ ] 📄 Documentation update
- [x] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `bun run lint`.
- [x] I have updated the documentation as needed.
- [x] I have added or updated tests for the changes in this PR.

### Thank you for your contribution!

_We appreciate your efforts in making this project better._