### PR TITLE
feat: add standalone installer scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,22 @@ As a **nvm but for git profiles**. One command to switch your name, email, and S
 --- 
 
 ## Installation
-gpx is published on the npm registry. Install it globally using your preferred package manager:
+
+### **Option 1 : Standalone Installer**
+You can install the compiled binaries directly using the terminal.
+
+**macOS & Linux**
+```bash
+curl -fsSL https://raw.githubusercontent.com/mindfiredigital/gpx/main/scripts/install.sh | bash
+```
+
+**Windows (PowerShell)**
+```powershell
+iwr -useb https://raw.githubusercontent.com/mindfiredigital/gpx/main/scripts/install.ps1 | iex
+```
+
+### **Option 2 : via npm**
+If you prefer, `gpx` is also published on the npm registry. Install it globally using your preferred package manager:
 
 ```bash
 # Using npm

--- a/gpx-docs/docs/Installation.md
+++ b/gpx-docs/docs/Installation.md
@@ -3,6 +3,27 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+## **Standalone Installer**
+
+<Tabs groupId="os">
+<TabItem value="mac-linux" label="macOS & Linux" default>
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mindfiredigital/gpx/main/scripts/install.sh | bash
+```
+
+</TabItem>
+<TabItem value="windows" label="Windows (PowerShell)">
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/mindfiredigital/gpx/main/scripts/install.ps1 | iex
+```
+
+</TabItem>
+</Tabs>
+
+## **npm**
+
 <Tabs groupId="package-managers">
 <TabItem value="npm" label="npm" default>
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,37 @@
+$ErrorActionPreference = "Stop"
+
+$Repo = "mindfiredigital/gpx"
+$BinaryName = "gpx-windows-x64.exe"
+$DownloadUrl = "https://github.com/$Repo/releases/latest/download/$BinaryName"
+
+# Setup installation directory
+$InstallBase = Join-Path $env:LOCALAPPDATA "mindfiredigital\gpx"
+$InstallBin = Join-Path $InstallBase "bin"
+$DestPath = Join-Path $InstallBin "gpx.exe"
+
+Write-Host "Installing GPX to $InstallBin..."
+
+# Create directory if it doesn't exist
+if (-not (Test-Path $InstallBin)) {
+    New-Item -ItemType Directory -Force -Path $InstallBin | Out-Null
+}
+
+# Download the binary
+Write-Host "Downloading latest version of GPX from $DownloadUrl..."
+Invoke-WebRequest -Uri $DownloadUrl -OutFile $DestPath -UseBasicParsing
+
+# Update user PATH environment variable if needed
+$UserPath = [Environment]::GetEnvironmentVariable("PATH", "User")
+$Paths = $UserPath -split ';'
+
+if ($Paths -notcontains $InstallBin) {
+    Write-Host "Adding $InstallBin to your PATH..."
+    $NewPath = "$UserPath;$InstallBin"
+    [Environment]::SetEnvironmentVariable("PATH", $NewPath, "User")
+    $env:PATH = "$env:PATH;$InstallBin"
+}
+
+Write-Host ""
+Write-Host "GPX was installed successfully!" -ForegroundColor Green
+Write-Host "Run 'gpx --help' to get started."
+Write-Host "(Note: You may need to restart your terminal for the PATH changes to take full effect.)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+# Repository information
+REPO="mindfiredigital/gpx"
+
+echo "Installing GPX..."
+
+# Determine OS
+OS="$(uname -s)"
+case "${OS}" in
+    Linux*)     target_os=linux;;
+    Darwin*)    target_os=darwin;;
+    *)          echo "Unsupported OS: ${OS}"; exit 1;;
+esac
+
+# Determine architecture
+ARCH="$(uname -m)"
+case "${ARCH}" in
+    x86_64|amd64)   target_arch=x64;;
+    aarch64|arm64)  target_arch=arm64;;
+    *)              echo "Unsupported architecture: ${ARCH}"; exit 1;;
+esac
+
+BINARY_NAME="gpx-${target_os}-${target_arch}"
+
+echo "Detected OS: ${target_os}"
+echo "Detected Arch: ${target_arch}"
+
+# Construct download URL
+DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${BINARY_NAME}"
+
+# Define installation directory
+INSTALL_DIR="/usr/local/bin"
+DEST="${INSTALL_DIR}/gpx"
+
+echo "Downloading latest version of GPX from ${DOWNLOAD_URL}..."
+
+# Download binary to a temporary location
+TMP_FILE=$(mktemp)
+if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
+    echo "Error: Failed to download binary from $DOWNLOAD_URL"
+    rm -f "$TMP_FILE"
+    exit 1
+fi
+
+chmod +x "$TMP_FILE"
+
+# Move to install directory
+echo "Installing to ${DEST}..."
+if [ -w "$INSTALL_DIR" ]; then
+    mv "$TMP_FILE" "$DEST"
+else
+    echo "Administrative privileges are required to install to ${INSTALL_DIR}."
+    sudo mv "$TMP_FILE" "$DEST"
+fi
+
+echo ""
+echo "GPX was installed successfully!"
+echo "Run 'gpx --help' to get started."


### PR DESCRIPTION
## Standalone Installation Scripts

## Description

### What does this PR do?
This PR introduces standalone, single-command installation scripts for macOS, Linux, and Windows, allowing users to install `gpx` directly without requiring Node.js or `npm` pre-installed.

- macOS & Linux (`scripts/install.sh`): 
  - Automatically detects the user's OS (`darwin` / `linux`) and architecture (`x64` / `arm64`)
  - Downloads the matching pre-compiled binary from GitHub Releases
  - Installs the executable binary directly to `/usr/local/bin/gpx`
- Windows (`scripts/install.ps1`):
  - Downloads `gpx-windows-x64.exe` from GitHub Releases
  - Installs the binary executable to `~\AppData\Local\mindfiredigital\gpx\bin\gpx.exe`
  - Automatically appends the binary folder to the user's `PATH` environment variable
- Documentation Updates:
  - Updated `README.md` with installation options
  - Updated Docusaurus documentation (`gpx-docs/docs/Installation.md`)

### Related Issues

_Link any related issue(s) with references to help reviewers understand the context._

- Closes :  
1. #101 
2.  #102 

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [x] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [x] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `bun run lint`.
- [x] I have updated the documentation as needed.
- [x] I have added or updated tests for the changes in this PR.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._