### PR TITLE
fix(release): add progress bars in standalone installer scripts for macOS, Linux, and Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,5 @@
 $ErrorActionPreference = "Stop"
+$ProgressPreference = 'SilentlyContinue'
 
 $Repo = "mindfiredigital/gpx"
 $BinaryName = "gpx-windows-x64.exe"
@@ -20,7 +21,11 @@ if (-not (Test-Path $InstallBin)) {
 $TempPath = Join-Path $InstallBin "gpx.exe.tmp"
 Write-Host "Downloading latest version of GPX from $DownloadUrl..."
 try {
-    Invoke-WebRequest -Uri $DownloadUrl -OutFile $TempPath -UseBasicParsing
+    if (Get-Command "curl.exe" -ErrorAction SilentlyContinue) {
+        curl.exe -# -fSL "$DownloadUrl" -o "$TempPath"
+    } else {
+        Invoke-WebRequest -Uri $DownloadUrl -OutFile $TempPath -UseBasicParsing
+    }
     Move-Item -Path $TempPath -Destination $DestPath -Force
 } finally {
     if (Test-Path $TempPath) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,7 +39,7 @@ echo "Downloading latest version of GPX from ${DOWNLOAD_URL}..."
 
 # Download binary to a temporary location
 TMP_FILE=$(mktemp)
-if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
+if ! curl -# -fSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
     echo "Error: Failed to download binary from $DOWNLOAD_URL"
     rm -f "$TMP_FILE"
     exit 1


### PR DESCRIPTION
## Pull Request Title

## Description

### What does this PR do?

This update adds a clean, single-line progress bar to both installer scripts:
- macOS & Linux (`scripts/install.sh`) : Updated `curl` flag to use `-#`, displaying a clean single-line progress bar.
- Windows (`scripts/install.ps1`) :
  - Uses `curl.exe -# -fSL` on Windows terminals to show the progress bar.
  - Suppressed the built-in PowerShell progress box (`$ProgressPreference = 'SilentlyContinue'`) to remove the blue banner overlay.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] 🚀 New feature
- [x] 📄 Documentation update
- [ ] ⚙️ Code refactoring
- [ ] 🔧 Configuration or CI/CD change
- [ ] 🧹 Maintenance or dependency update

## Checklist

_Please ensure the following have been completed before submitting:_

- [x] I have linted my code using `bun run lint`.
- [x] I have updated the documentation as needed.
- [x] I have added or updated tests for the changes in this PR.

---

### Thank you for your contribution!

_We appreciate your efforts in making this project better._